### PR TITLE
Show Claude org on accounts and keep personal + team seats for the same email

### DIFF
--- a/src/Sources/AppDelegate.swift
+++ b/src/Sources/AppDelegate.swift
@@ -408,6 +408,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUserNoti
 
     private func startMonitoringAuthDirectory() {
         authDirectoryMonitor = AuthDirectoryMonitor(debounceInterval: 0.5, logPrefix: "[AppDelegate]") {
+            ClaudeAuthSeatFiles.migrateCanonicalFiles(in: AuthPaths.authDirectory)
             NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
         }
         authDirectoryMonitor?.start()

--- a/src/Sources/AuthStatus.swift
+++ b/src/Sources/AuthStatus.swift
@@ -56,6 +56,10 @@ struct AuthAccount: Identifiable, Equatable {
     let expired: Date?
     let filePath: URL
     let isDisabled: Bool
+    /// Raw `organization_name` from the Claude auth JSON, if present.
+    let organizationName: String?
+    /// Classified Settings/quota suffix (`Personal Max`, `{org} (Team)`, or raw name).
+    let claudeSeatLabel: String?
 
     var isExpired: Bool {
         guard let expired else { return false }
@@ -63,9 +67,18 @@ struct AuthAccount: Identifiable, Equatable {
     }
 
     var displayName: String {
-        if let email, !email.isEmpty { return email }
-        if let login, !login.isEmpty { return login }
-        return id
+        let base: String
+        if let email, !email.isEmpty {
+            base = email
+        } else if let login, !login.isEmpty {
+            base = login
+        } else {
+            return id
+        }
+        if type == .claude, let claudeSeatLabel, !claudeSeatLabel.isEmpty {
+            return "\(base) · \(claudeSeatLabel)"
+        }
+        return base
     }
 
     static func == (lhs: AuthAccount, rhs: AuthAccount) -> Bool {
@@ -102,6 +115,7 @@ class AuthManager: ObservableObject {
 
     func checkAuthStatus() {
         let authDir = AuthPaths.authDirectory
+        ClaudeAuthSeatFiles.migrateCanonicalFiles(in: authDir)
         let files: [URL]
         do {
             files = try FileManager.default.contentsOfDirectory(at: authDir, includingPropertiesForKeys: nil)
@@ -181,6 +195,20 @@ class AuthManager: ObservableObject {
 
         NSLog("[AuthStatus] Found type '%@' in %@", typeString, file.lastPathComponent)
 
+        let organizationName: String?
+        let claudeSeatLabel: String?
+        if serviceType == .claude {
+            let fields = ClaudeAuthSeatFiles.organizationFields(from: json)
+            organizationName = fields.name
+            claudeSeatLabel = ClaudeAuthSeatFiles.seatDisplayLabel(
+                email: json["email"] as? String,
+                json: json
+            )
+        } else {
+            organizationName = nil
+            claudeSeatLabel = nil
+        }
+
         return AuthAccount(
             id: file.lastPathComponent,
             email: json["email"] as? String,
@@ -188,7 +216,9 @@ class AuthManager: ObservableObject {
             type: serviceType,
             expired: parseExpiry(json["expired"] as? String),
             filePath: file,
-            isDisabled: json["disabled"] as? Bool ?? false
+            isDisabled: json["disabled"] as? Bool ?? false,
+            organizationName: organizationName,
+            claudeSeatLabel: claudeSeatLabel
         )
     }
 

--- a/src/Sources/ClaudeAuthSeatFiles.swift
+++ b/src/Sources/ClaudeAuthSeatFiles.swift
@@ -64,8 +64,7 @@ enum ClaudeAuthSeatFiles {
 
     /// UUID when present (stable); otherwise a filesystem-safe organization name.
     static func uniqueFilename(email: String, fields: OrganizationFields) -> String? {
-        let email = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !email.isEmpty else { return nil }
+        guard let email = filenameSafeEmail(email) else { return nil }
         if let suffix = filenameSafeSuffix(fields.uuid) ?? filenameSafeSuffix(fields.name) {
             return "claude-\(email)-\(suffix).json"
         }
@@ -134,10 +133,14 @@ enum ClaudeAuthSeatFiles {
             return nil
         }
 
-        let dest = url.deletingLastPathComponent().appendingPathComponent(destName)
+        let destDir = url.deletingLastPathComponent().standardizedFileURL
+        let dest = destDir.appendingPathComponent(destName)
+        guard dest.deletingLastPathComponent().standardizedFileURL == destDir else {
+            NSLog("[ClaudeAuthSeatFiles] Refusing destination outside auth directory: %@", destName)
+            return nil
+        }
         do {
-            try data.write(to: dest, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dest.path)
+            try writeRestrictedFile(data, to: dest)
             if url.standardizedFileURL != dest.standardizedFileURL {
                 try FileManager.default.removeItem(at: url)
             }
@@ -206,14 +209,12 @@ enum ClaudeAuthSeatFiles {
 
     private static func isPersonalMaxHint(_ raw: String) -> Bool {
         let value = raw.lowercased()
-        return value.contains("claude_max")
-            || value == "max"
-            || value.contains("default_claude_max")
+        return value.contains("claude_max") || value == "max"
     }
 
     private static func isPersonalProHint(_ raw: String) -> Bool {
         let value = raw.lowercased()
-        return value.contains("claude_pro") || value == "pro" || value == "claude_pro"
+        return value.contains("claude_pro") || value == "pro"
     }
 
     private static func isTeamHint(_ raw: String) -> Bool {
@@ -293,6 +294,45 @@ enum ClaudeAuthSeatFiles {
         guard let string = value as? String else { return nil }
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Rejects values that would escape the auth directory as a path component.
+    /// `@` stays so existing `claude-{email}-{uuid}.json` names keep matching.
+    private static func filenameSafeEmail(_ raw: String) -> String? {
+        let email = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !email.isEmpty else { return nil }
+        if email.contains("/") || email.contains("\\") || email == "." || email == ".." {
+            NSLog("[ClaudeAuthSeatFiles] Refusing unsafe email in filename: %@", email)
+            return nil
+        }
+        return email
+    }
+
+    /// Creates `dest` at 0o600 so OAuth tokens are never written world-readable.
+    private static func writeRestrictedFile(_ data: Data, to dest: URL) throws {
+        let temp = dest.deletingLastPathComponent()
+            .appendingPathComponent(".claude-seat-\(UUID().uuidString).tmp")
+        guard FileManager.default.createFile(
+            atPath: temp.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw NSError(
+                domain: "ClaudeAuthSeatFiles",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create \(temp.lastPathComponent)"]
+            )
+        }
+        do {
+            if FileManager.default.fileExists(atPath: dest.path) {
+                _ = try FileManager.default.replaceItemAt(dest, withItemAt: temp)
+            } else {
+                try FileManager.default.moveItem(at: temp, to: dest)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: temp)
+            throw error
+        }
     }
 
     private static func filenameSafeSuffix(_ raw: String?) -> String? {

--- a/src/Sources/ClaudeAuthSeatFiles.swift
+++ b/src/Sources/ClaudeAuthSeatFiles.swift
@@ -1,0 +1,324 @@
+import Foundation
+
+/// Keeps personal Max and org Claude seats on the same email from clobbering
+/// each other. CLIProxyAPI always writes `claude-{email}.json`; after the file
+/// is complete we rename it to `claude-{email}-{organization_uuid}.json` so the
+/// next `-claude-login` can create a fresh canonical file for the other org.
+enum ClaudeAuthSeatFiles {
+    struct OrganizationFields: Equatable {
+        var uuid: String?
+        var name: String?
+
+        var hasSeatIdentity: Bool {
+            uuid != nil || name != nil
+        }
+    }
+
+    static func organizationFields(from json: [String: Any]) -> OrganizationFields {
+        var uuid = nonemptyString(json["organization_uuid"])
+        var name = nonemptyString(json["organization_name"])
+        if (uuid == nil || name == nil), let org = json["organization"] as? [String: Any] {
+            if uuid == nil {
+                uuid = nonemptyString(org["uuid"]) ?? nonemptyString(org["organization_uuid"])
+            }
+            if name == nil {
+                name = nonemptyString(org["name"]) ?? nonemptyString(org["organization_name"])
+            }
+        }
+        return OrganizationFields(uuid: uuid, name: name)
+    }
+
+    /// Settings / quota suffix after the email: `Personal Max`, `{org} (Team)`,
+    /// or the raw organization name when we cannot classify the plan.
+    ///
+    /// CLIProxyAPI auth files have no subscription field today. Prefer explicit
+    /// `organization_type` / `rate_limit_tier` when present; otherwise use a
+    /// conservative name heuristic (person-style names → Personal Max; ALL-CAPS
+    /// or company-suffix names → Team). Ambiguous names are shown as-is.
+    static func seatDisplayLabel(email: String?, json: [String: Any]) -> String? {
+        let fields = organizationFields(from: json)
+        if let fromPlan = labelFromPlanHints(json: json, organizationName: fields.name) {
+            return fromPlan
+        }
+        return seatDisplayLabel(email: email, organizationName: fields.name)
+    }
+
+    static func seatDisplayLabel(email: String?, organizationName: String?) -> String? {
+        guard let name = organizationName else { return nil }
+        if looksLikePersonalOrganizationName(name, email: email) {
+            return "Personal Max"
+        }
+        if looksLikeTeamOrganizationName(name) {
+            return "\(name) (Team)"
+        }
+        return name
+    }
+
+    static func canonicalFilename(email: String) -> String {
+        "claude-\(email).json"
+    }
+
+    static func isCanonicalClaudeEmailFile(_ filename: String, email: String) -> Bool {
+        filename == canonicalFilename(email: email)
+    }
+
+    /// UUID when present (stable); otherwise a filesystem-safe organization name.
+    static func uniqueFilename(email: String, fields: OrganizationFields) -> String? {
+        let email = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !email.isEmpty else { return nil }
+        if let suffix = filenameSafeSuffix(fields.uuid) ?? filenameSafeSuffix(fields.name) {
+            return "claude-\(email)-\(suffix).json"
+        }
+        return nil
+    }
+
+    /// Renames complete `claude-{email}.json` files that carry org identity.
+    /// Incomplete / empty / non-Claude files are left untouched so a mid-write
+    /// from CLIProxyAPI can be retried on the next directory-watcher tick.
+    @discardableResult
+    static func migrateCanonicalFiles(in directory: URL) -> [URL] {
+        let files: [URL]
+        do {
+            files = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.fileSizeKey]
+            )
+        } catch {
+            NSLog("[ClaudeAuthSeatFiles] Failed to list %@: %@", directory.path, error.localizedDescription)
+            return []
+        }
+
+        var destinations: [URL] = []
+        for file in files where file.pathExtension.lowercased() == "json" {
+            if let dest = migrateFile(at: file) {
+                destinations.append(dest)
+            }
+        }
+        return destinations
+    }
+
+    @discardableResult
+    static func migrateFile(at url: URL) -> URL? {
+        let filename = url.lastPathComponent
+        guard filename.hasPrefix("claude-"), filename.lowercased().hasSuffix(".json") else {
+            return nil
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+
+        let size = fileSize(at: url)
+        guard size > 0 else {
+            NSLog("[ClaudeAuthSeatFiles] Skipping empty or mid-write file %@", filename)
+            return nil
+        }
+
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String,
+              type.lowercased() == "claude" else {
+            return nil
+        }
+
+        guard let email = nonemptyString(json["email"]) else { return nil }
+
+        let fields = organizationFields(from: json)
+        guard let destName = uniqueFilename(email: email, fields: fields), destName != filename else {
+            return nil
+        }
+
+        // Canonical `claude-{email}.json` always moves once org identity exists.
+        // Already-suffixed workaround names (`claude-{email}-kaikaku.json`) move
+        // onto the stable UUID filename so a later re-auth refreshes that file
+        // instead of leaving a sibling.
+        let isCanonical = isCanonicalClaudeEmailFile(filename, email: email)
+        if !isCanonical && fields.uuid == nil {
+            return nil
+        }
+
+        let dest = url.deletingLastPathComponent().appendingPathComponent(destName)
+        do {
+            try data.write(to: dest, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dest.path)
+            if url.standardizedFileURL != dest.standardizedFileURL {
+                try FileManager.default.removeItem(at: url)
+            }
+            NSLog("[ClaudeAuthSeatFiles] Renamed %@ -> %@", filename, destName)
+            return dest
+        } catch {
+            NSLog("[ClaudeAuthSeatFiles] Failed to rename %@: %@", filename, error.localizedDescription)
+            return nil
+        }
+    }
+
+    // MARK: - Plan / name classification
+
+    private static let companySuffixes: Set<String> = [
+        "inc", "inc.", "llc", "ltd", "ltd.", "corp", "corporation",
+        "gmbh", "ag", "plc", "company", "co", "co.", "team", "labs",
+        "studio", "technologies", "tech", "limited"
+    ]
+
+    private static let nameParticles: Set<String> = [
+        "van", "von", "de", "da", "del", "della", "di", "la", "le", "du",
+        "st", "st.", "der", "den", "bin", "al"
+    ]
+
+    private static func labelFromPlanHints(json: [String: Any], organizationName: String?) -> String? {
+        let hints = planHintStrings(from: json)
+        guard !hints.isEmpty else { return nil }
+
+        if hints.contains(where: isPersonalMaxHint) {
+            return "Personal Max"
+        }
+        if hints.contains(where: { isEnterpriseHint($0) }) {
+            if let organizationName { return "\(organizationName) (Enterprise)" }
+            return "Enterprise"
+        }
+        if hints.contains(where: isTeamHint) {
+            if let organizationName { return "\(organizationName) (Team)" }
+            return "Team"
+        }
+        if hints.contains(where: isPersonalProHint) {
+            return "Personal Pro"
+        }
+        return nil
+    }
+
+    private static func planHintStrings(from json: [String: Any]) -> [String] {
+        var values: [String] = []
+        let keys = [
+            "organization_type", "rate_limit_tier", "billing_type",
+            "plan", "subscription_type", "account_type"
+        ]
+        for key in keys {
+            if let value = nonemptyString(json[key]) {
+                values.append(value)
+            }
+        }
+        if let org = json["organization"] as? [String: Any] {
+            for key in keys + ["type"] {
+                if let value = nonemptyString(org[key]) {
+                    values.append(value)
+                }
+            }
+        }
+        return values
+    }
+
+    private static func isPersonalMaxHint(_ raw: String) -> Bool {
+        let value = raw.lowercased()
+        return value.contains("claude_max")
+            || value == "max"
+            || value.contains("default_claude_max")
+    }
+
+    private static func isPersonalProHint(_ raw: String) -> Bool {
+        let value = raw.lowercased()
+        return value.contains("claude_pro") || value == "pro" || value == "claude_pro"
+    }
+
+    private static func isTeamHint(_ raw: String) -> Bool {
+        let value = raw.lowercased()
+        return value.contains("claude_team") || value == "team" || value.contains("team_plan")
+    }
+
+    private static func isEnterpriseHint(_ raw: String) -> Bool {
+        let value = raw.lowercased()
+        return value.contains("enterprise")
+    }
+
+    static func looksLikePersonalOrganizationName(_ name: String, email: String?) -> Bool {
+        if let email, looksLikeEmailPersonalOrganization(name, email: email) {
+            return true
+        }
+        return looksLikePersonDisplayName(name)
+    }
+
+    /// Claude often names the personal org `{email}'s Organization`.
+    static func looksLikeEmailPersonalOrganization(_ name: String, email: String) -> Bool {
+        let lowered = name.lowercased()
+        let emailLower = email.lowercased()
+        if lowered == "\(emailLower)'s organization" || lowered == "\(emailLower)’s organization" {
+            return true
+        }
+        let local = String(emailLower.split(separator: "@").first ?? "")
+        if !local.isEmpty && (lowered == "\(local)'s organization" || lowered == "\(local)’s organization") {
+            return true
+        }
+        return false
+    }
+
+    /// Anthropic's personal Max org is often the user's display name ("Josef Chen").
+    static func looksLikePersonDisplayName(_ name: String) -> Bool {
+        let parts = name.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard (2...4).contains(parts.count) else { return false }
+
+        var contentWords = 0
+        for part in parts {
+            let lower = part.lowercased()
+            if companySuffixes.contains(lower) { return false }
+            if nameParticles.contains(lower) { continue }
+            guard looksLikeNameToken(part) else { return false }
+            contentWords += 1
+        }
+        return contentWords >= 2
+    }
+
+    static func looksLikeTeamOrganizationName(_ name: String) -> Bool {
+        if looksLikePersonDisplayName(name) { return false }
+        let parts = name.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard !parts.isEmpty else { return false }
+        if parts.contains(where: { companySuffixes.contains($0.lowercased()) }) {
+            return true
+        }
+        if parts.count == 1 {
+            let token = parts[0]
+            let letters = token.filter(\.isLetter)
+            let hasLower = token.contains(where: { $0.isLowercase })
+            if letters.count >= 3 && !hasLower && token == token.uppercased() {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func looksLikeNameToken(_ token: String) -> Bool {
+        guard let first = token.first, first.isUppercase else { return false }
+        guard token.contains(where: { $0.isLowercase }) else { return false }
+        return token.allSatisfy { $0.isLetter || $0 == "-" || $0 == "'" }
+    }
+
+    // MARK: - Helpers
+
+    static func nonemptyString(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func filenameSafeSuffix(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let mapped = raw.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.alphanumerics.contains(scalar)
+                || scalar == "-" || scalar == "." || scalar == "_" {
+                return Character(scalar)
+            }
+            return "-"
+        }
+        var result = String(mapped)
+        while result.contains("--") {
+            result = result.replacingOccurrences(of: "--", with: "-")
+        }
+        result = result.trimmingCharacters(in: CharacterSet(charactersIn: "-."))
+        return result.isEmpty ? nil : result
+    }
+
+    private static func fileSize(at url: URL) -> Int {
+        // Prefer attributesOfItem — URL resource values can stay stale after a
+        // mid-write grows the file on the same URL instance.
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let size = attrs[.size] as? NSNumber {
+            return size.intValue
+        }
+        return 0
+    }
+}

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -337,8 +337,12 @@ class ServerManager: ObservableObject {
                 NSLog("[Auth] Process terminated with exit code: %d", process.terminationStatus)
                 guard process.terminationStatus == 0 else { return }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    ClaudeAuthSeatFiles.migrateCanonicalFiles(in: AuthPaths.authDirectory)
-                    NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        ClaudeAuthSeatFiles.migrateCanonicalFiles(in: AuthPaths.authDirectory)
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
+                        }
+                    }
                 }
             }
 

--- a/src/Sources/ServerManager.swift
+++ b/src/Sources/ServerManager.swift
@@ -337,6 +337,7 @@ class ServerManager: ObservableObject {
                 NSLog("[Auth] Process terminated with exit code: %d", process.terminationStatus)
                 guard process.terminationStatus == 0 else { return }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    ClaudeAuthSeatFiles.migrateCanonicalFiles(in: AuthPaths.authDirectory)
                     NotificationCenter.default.post(name: .authDirectoryChanged, object: nil)
                 }
             }

--- a/src/Tests/CLIProxyMenuBarTests/ClaudeAuthSeatFilesTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/ClaudeAuthSeatFilesTests.swift
@@ -1,0 +1,360 @@
+import XCTest
+@testable import CLIProxyMenuBar
+
+final class ClaudeAuthSeatFilesTests: XCTestCase {
+    private let email = "josef@kaikaku.ai"
+    private let personalUUID = "01a2b962-674f-47df-afdd-fc21609e4987"
+    private let teamUUID = "b305c0b8-71d7-4d4c-8cab-47e9f78eea3e"
+
+    private var scratch: URL!
+
+    override func setUp() {
+        super.setUp()
+        scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-seat-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: scratch)
+        scratch = nil
+        super.tearDown()
+    }
+
+    // MARK: - Org field parsing
+
+    func testParsesTopLevelOrganizationFields() {
+        let fields = ClaudeAuthSeatFiles.organizationFields(from: [
+            "organization_uuid": personalUUID,
+            "organization_name": "Josef Chen"
+        ])
+        XCTAssertEqual(fields.uuid, personalUUID)
+        XCTAssertEqual(fields.name, "Josef Chen")
+        XCTAssertTrue(fields.hasSeatIdentity)
+    }
+
+    func testParsesNestedOrganizationObject() {
+        let fields = ClaudeAuthSeatFiles.organizationFields(from: [
+            "organization": [
+                "uuid": teamUUID,
+                "name": "KAIKAKU"
+            ]
+        ])
+        XCTAssertEqual(fields.uuid, teamUUID)
+        XCTAssertEqual(fields.name, "KAIKAKU")
+    }
+
+    func testBlankOrganizationFieldsAreMissing() {
+        let fields = ClaudeAuthSeatFiles.organizationFields(from: [
+            "organization_uuid": "  ",
+            "organization_name": ""
+        ])
+        XCTAssertNil(fields.uuid)
+        XCTAssertNil(fields.name)
+        XCTAssertFalse(fields.hasSeatIdentity)
+    }
+
+    // MARK: - Display labels
+
+    func testPersonStyleNameIsPersonalMax() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: "Josef Chen"),
+            "Personal Max"
+        )
+    }
+
+    func testAllCapsOrgIsTeam() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: "KAIKAKU"),
+            "KAIKAKU (Team)"
+        )
+    }
+
+    func testCompanySuffixIsTeam() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: "Acme Inc"),
+            "Acme Inc (Team)"
+        )
+    }
+
+    func testAmbiguousNameIsShownRaw() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: "Pessoal"),
+            "Pessoal"
+        )
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: "Acme"),
+            "Acme"
+        )
+    }
+
+    func testEmailPossessiveOrganizationIsPersonalMax() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(
+                email: email,
+                organizationName: "josef@kaikaku.ai's Organization"
+            ),
+            "Personal Max"
+        )
+    }
+
+    func testExplicitOrganizationTypeWinsOverName() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, json: [
+                "organization_name": "Pessoal",
+                "organization_type": "claude_max"
+            ]),
+            "Personal Max"
+        )
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, json: [
+                "organization_name": "Josef Chen",
+                "organization_type": "claude_team"
+            ]),
+            "Josef Chen (Team)"
+        )
+    }
+
+    func testMissingOrganizationNameYieldsNoSuffix() {
+        XCTAssertNil(ClaudeAuthSeatFiles.seatDisplayLabel(email: email, organizationName: nil))
+    }
+
+    func testSettingsRowShowsEmailAndClassifiedLabel() {
+        let personal = AuthAccount(
+            id: "claude-\(email)-\(personalUUID).json",
+            email: email,
+            login: nil,
+            type: .claude,
+            expired: nil,
+            filePath: scratch.appendingPathComponent("personal.json"),
+            isDisabled: false,
+            organizationName: "Josef Chen",
+            claudeSeatLabel: ClaudeAuthSeatFiles.seatDisplayLabel(
+                email: email,
+                organizationName: "Josef Chen"
+            )
+        )
+        let team = AuthAccount(
+            id: "claude-\(email)-\(teamUUID).json",
+            email: email,
+            login: nil,
+            type: .claude,
+            expired: nil,
+            filePath: scratch.appendingPathComponent("team.json"),
+            isDisabled: false,
+            organizationName: "KAIKAKU",
+            claudeSeatLabel: ClaudeAuthSeatFiles.seatDisplayLabel(
+                email: email,
+                organizationName: "KAIKAKU"
+            )
+        )
+
+        XCTAssertEqual(personal.displayName, "\(email) · Personal Max")
+        XCTAssertEqual(team.displayName, "\(email) · KAIKAKU (Team)")
+    }
+
+    func testMissingLabelShowsEmailOnly() {
+        let account = AuthAccount(
+            id: "claude-\(email).json",
+            email: email,
+            login: nil,
+            type: .claude,
+            expired: nil,
+            filePath: scratch.appendingPathComponent("plain.json"),
+            isDisabled: false,
+            organizationName: nil,
+            claudeSeatLabel: nil
+        )
+        XCTAssertEqual(account.displayName, email)
+    }
+
+    // MARK: - Filenames
+
+    func testUniqueFilenamePrefersUUID() {
+        let name = ClaudeAuthSeatFiles.uniqueFilename(
+            email: email,
+            fields: .init(uuid: personalUUID, name: "Josef Chen")
+        )
+        XCTAssertEqual(name, "claude-\(email)-\(personalUUID).json")
+    }
+
+    func testCanonicalFilenameMatchesCLIProxyAPI() {
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.canonicalFilename(email: email),
+            "claude-\(email).json"
+        )
+        XCTAssertTrue(
+            ClaudeAuthSeatFiles.isCanonicalClaudeEmailFile("claude-\(email).json", email: email)
+        )
+        XCTAssertFalse(
+            ClaudeAuthSeatFiles.isCanonicalClaudeEmailFile("claude-\(email)-kaikaku.json", email: email)
+        )
+    }
+
+    // MARK: - Rename / collision
+
+    func testTwoOrgsSameEmailBecomeTwoUUIDFiles() throws {
+        try writeClaudeFile(
+            named: "claude-\(email).json",
+            email: email,
+            orgName: "Josef Chen",
+            orgUUID: personalUUID,
+            marker: "personal-token"
+        )
+        XCTAssertNotNil(ClaudeAuthSeatFiles.migrateFile(at: scratch.appendingPathComponent("claude-\(email).json")))
+
+        try writeClaudeFile(
+            named: "claude-\(email).json",
+            email: email,
+            orgName: "KAIKAKU",
+            orgUUID: teamUUID,
+            marker: "team-token"
+        )
+        XCTAssertNotNil(ClaudeAuthSeatFiles.migrateFile(at: scratch.appendingPathComponent("claude-\(email).json")))
+
+        let names = jsonNames()
+        XCTAssertFalse(names.contains("claude-\(email).json"))
+        XCTAssertTrue(names.contains("claude-\(email)-\(personalUUID).json"))
+        XCTAssertTrue(names.contains("claude-\(email)-\(teamUUID).json"))
+        XCTAssertEqual(marker(in: "claude-\(email)-\(personalUUID).json"), "personal-token")
+        XCTAssertEqual(marker(in: "claude-\(email)-\(teamUUID).json"), "team-token")
+    }
+
+    func testReauthSameOrgRefreshesUUIDFileOnly() throws {
+        try writeClaudeFile(
+            named: "claude-\(email)-\(personalUUID).json",
+            email: email,
+            orgName: "Josef Chen",
+            orgUUID: personalUUID,
+            marker: "old-personal"
+        )
+        try writeClaudeFile(
+            named: "claude-\(email)-\(teamUUID).json",
+            email: email,
+            orgName: "KAIKAKU",
+            orgUUID: teamUUID,
+            marker: "team-token"
+        )
+        try writeClaudeFile(
+            named: "claude-\(email).json",
+            email: email,
+            orgName: "Josef Chen",
+            orgUUID: personalUUID,
+            marker: "new-personal"
+        )
+
+        ClaudeAuthSeatFiles.migrateCanonicalFiles(in: scratch)
+
+        let names = jsonNames()
+        XCTAssertFalse(names.contains("claude-\(email).json"))
+        XCTAssertEqual(marker(in: "claude-\(email)-\(personalUUID).json"), "new-personal")
+        XCTAssertEqual(marker(in: "claude-\(email)-\(teamUUID).json"), "team-token")
+    }
+
+    func testMissingOrgFieldsLeaveCanonicalName() throws {
+        try writeJSON(
+            named: "claude-\(email).json",
+            [
+                "type": "claude",
+                "email": email,
+                "access_token": "x"
+            ]
+        )
+
+        XCTAssertNil(ClaudeAuthSeatFiles.migrateFile(at: scratch.appendingPathComponent("claude-\(email).json")))
+        XCTAssertEqual(jsonNames(), ["claude-\(email).json"])
+    }
+
+    func testAlreadySuffixedNameMigratesToUUID() throws {
+        try writeClaudeFile(
+            named: "claude-\(email)-kaikaku.json",
+            email: email,
+            orgName: "KAIKAKU",
+            orgUUID: teamUUID,
+            marker: "team-token"
+        )
+
+        ClaudeAuthSeatFiles.migrateCanonicalFiles(in: scratch)
+
+        let names = jsonNames()
+        XCTAssertFalse(names.contains("claude-\(email)-kaikaku.json"))
+        XCTAssertTrue(names.contains("claude-\(email)-\(teamUUID).json"))
+        XCTAssertEqual(marker(in: "claude-\(email)-\(teamUUID).json"), "team-token")
+    }
+
+    func testEmptyAndIncompleteJSONAreLeftAlone() throws {
+        let empty = scratch.appendingPathComponent("claude-\(email).json")
+        FileManager.default.createFile(atPath: empty.path, contents: Data(), attributes: nil)
+        XCTAssertNil(ClaudeAuthSeatFiles.migrateFile(at: empty))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: empty.path))
+
+        try "{".write(to: empty, atomically: true, encoding: .utf8)
+        XCTAssertNil(ClaudeAuthSeatFiles.migrateFile(at: empty))
+        XCTAssertEqual(try String(contentsOf: empty, encoding: .utf8), "{")
+    }
+
+    func testCodexAndOtherProvidersAreNotRenamed() throws {
+        try writeJSON(
+            named: "codex-\(email).json",
+            [
+                "type": "codex",
+                "email": email,
+                "organization_uuid": personalUUID,
+                "organization_name": "Josef Chen"
+            ]
+        )
+        try writeJSON(
+            named: "gemini-\(email).json",
+            [
+                "type": "gemini",
+                "email": email,
+                "organization_uuid": personalUUID
+            ]
+        )
+
+        ClaudeAuthSeatFiles.migrateCanonicalFiles(in: scratch)
+
+        XCTAssertEqual(Set(jsonNames()), [
+            "codex-\(email).json",
+            "gemini-\(email).json"
+        ])
+    }
+
+    // MARK: - Scratch helpers
+
+    private func writeClaudeFile(
+        named: String,
+        email: String,
+        orgName: String,
+        orgUUID: String,
+        marker: String
+    ) throws {
+        try writeJSON(named: named, [
+            "type": "claude",
+            "email": email,
+            "organization_name": orgName,
+            "organization_uuid": orgUUID,
+            "access_token": marker
+        ])
+    }
+
+    private func writeJSON(named: String, _ object: [String: Any]) throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        try data.write(to: scratch.appendingPathComponent(named), options: .atomic)
+    }
+
+    private func jsonNames() -> [String] {
+        ((try? FileManager.default.contentsOfDirectory(atPath: scratch.path)) ?? [])
+            .filter { $0.hasSuffix(".json") }
+            .sorted()
+    }
+
+    private func marker(in filename: String) -> String? {
+        let url = scratch.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["access_token"] as? String
+    }
+}

--- a/src/Tests/CLIProxyMenuBarTests/ClaudeAuthSeatFilesTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/ClaudeAuthSeatFilesTests.swift
@@ -113,6 +113,26 @@ final class ClaudeAuthSeatFilesTests: XCTestCase {
             ]),
             "Josef Chen (Team)"
         )
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, json: [
+                "organization_name": "KAIKAKU",
+                "organization_type": "enterprise"
+            ]),
+            "KAIKAKU (Enterprise)"
+        )
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, json: [
+                "organization_type": "enterprise"
+            ]),
+            "Enterprise"
+        )
+        XCTAssertEqual(
+            ClaudeAuthSeatFiles.seatDisplayLabel(email: email, json: [
+                "organization_name": "Josef Chen",
+                "organization_type": "claude_pro"
+            ]),
+            "Personal Pro"
+        )
     }
 
     func testMissingOrganizationNameYieldsNoSuffix() {
@@ -176,6 +196,15 @@ final class ClaudeAuthSeatFilesTests: XCTestCase {
             fields: .init(uuid: personalUUID, name: "Josef Chen")
         )
         XCTAssertEqual(name, "claude-\(email)-\(personalUUID).json")
+    }
+
+    func testUniqueFilenameRejectsPathEscapingEmail() {
+        let fields = ClaudeAuthSeatFiles.OrganizationFields(uuid: personalUUID, name: "Josef Chen")
+        XCTAssertNil(ClaudeAuthSeatFiles.uniqueFilename(email: "../evil@x.com", fields: fields))
+        XCTAssertNil(ClaudeAuthSeatFiles.uniqueFilename(email: "foo/bar@x.com", fields: fields))
+        XCTAssertNil(ClaudeAuthSeatFiles.uniqueFilename(email: "foo\\bar@x.com", fields: fields))
+        XCTAssertNil(ClaudeAuthSeatFiles.uniqueFilename(email: ".", fields: fields))
+        XCTAssertNil(ClaudeAuthSeatFiles.uniqueFilename(email: "..", fields: fields))
     }
 
     func testCanonicalFilenameMatchesCLIProxyAPI() {
@@ -263,6 +292,42 @@ final class ClaudeAuthSeatFilesTests: XCTestCase {
 
         XCTAssertNil(ClaudeAuthSeatFiles.migrateFile(at: scratch.appendingPathComponent("claude-\(email).json")))
         XCTAssertEqual(jsonNames(), ["claude-\(email).json"])
+    }
+
+    func testNameOnlyCanonicalFileMigratesToSanitizedSuffix() throws {
+        try writeJSON(
+            named: "claude-\(email).json",
+            [
+                "type": "claude",
+                "email": email,
+                "organization_name": "Acme Inc",
+                "access_token": "name-only-token"
+            ]
+        )
+
+        let dest = ClaudeAuthSeatFiles.migrateFile(
+            at: scratch.appendingPathComponent("claude-\(email).json")
+        )
+        XCTAssertEqual(dest?.lastPathComponent, "claude-\(email)-Acme-Inc.json")
+        XCTAssertEqual(jsonNames(), ["claude-\(email)-Acme-Inc.json"])
+        XCTAssertEqual(marker(in: "claude-\(email)-Acme-Inc.json"), "name-only-token")
+        XCTAssertEqual(posixPermissions(of: "claude-\(email)-Acme-Inc.json"), 0o600)
+    }
+
+    func testMigratedDestinationIsOwnerReadableOnly() throws {
+        try writeClaudeFile(
+            named: "claude-\(email).json",
+            email: email,
+            orgName: "Josef Chen",
+            orgUUID: personalUUID,
+            marker: "personal-token"
+        )
+
+        let dest = ClaudeAuthSeatFiles.migrateFile(
+            at: scratch.appendingPathComponent("claude-\(email).json")
+        )
+        XCTAssertEqual(dest?.lastPathComponent, "claude-\(email)-\(personalUUID).json")
+        XCTAssertEqual(posixPermissions(of: "claude-\(email)-\(personalUUID).json"), 0o600)
     }
 
     func testAlreadySuffixedNameMigratesToUUID() throws {
@@ -356,5 +421,14 @@ final class ClaudeAuthSeatFilesTests: XCTestCase {
             return nil
         }
         return json["access_token"] as? String
+    }
+
+    private func posixPermissions(of filename: String) -> Int? {
+        let url = scratch.appendingPathComponent(filename)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let mode = attrs[.posixPermissions] as? NSNumber else {
+            return nil
+        }
+        return mode.intValue
     }
 }


### PR DESCRIPTION
## Summary
- Settings and quota rows now label Claude seats as `email · Personal Max` or `email · {org} (Team)` (raw `organization_name` when the plan cannot be classified). Live files have no subscription field — personal Max is detected from a person-style org name (`Josef Chen`) or `{email}'s Organization`; Team from ALL-CAPS / company-suffix names or explicit `organization_type`.
- After Claude login and on auth-directory changes, a complete `claude-{email}.json` is renamed to `claude-{email}-{organization_uuid}.json` so the next Add Account can write a fresh canonical file for the other org picker choice. Already-suffixed workaround names (e.g. `-kaikaku`) are moved onto that UUID filename once so re-auth refreshes the same seat instead of creating a sibling.
- AuthManager still loads every `type: claude` JSON, so two files with the same email and different org UUIDs are two enabled seats and participate in failover independently. Codex/Gemini/Grok files are not touched.

## Test plan
- [ ] Add Account for Claude, pick **personal Max** in the org picker; Settings shows `you@domain · Personal Max` and the auth dir has `claude-{email}-{personal-uuid}.json`.
- [ ] Add Account again with the same Google/Claude email, pick the **company org**; Settings shows two rows (`Personal Max` and `{ORG} (Team)`), both files remain, neither is overwritten.
- [ ] Re-auth the same org: only that UUID file is refreshed; the other org’s file is unchanged.
- [ ] Incomplete / empty `claude-{email}.json` (mid-write) is left alone until the JSON is valid.
- [ ] Codex/Gemini/Grok auth files are not renamed.
- [ ] With both Claude seats enabled, sequential failover treats them as two accounts.


Made with [Cursor](https://cursor.com)