### PR TITLE
feat: add Antigravity Gemini 3.8 Flash model

### DIFF
--- a/src/Sources/DroidProxyModelCatalog.swift
+++ b/src/Sources/DroidProxyModelCatalog.swift
@@ -315,6 +315,11 @@ enum DroidProxyModelCatalog {
                 displayName: "Gemini 3.7 Flash (High)"
             ),
             antigravityModel(
+                baseModel: "gemini-3.8-flash-high",
+                idSlug: "gemini-3.8-flash-high",
+                displayName: "Gemini 3.8 Flash (High)"
+            ),
+            antigravityModel(
                 baseModel: "gemini-3.1-flash-lite",
                 idSlug: "gemini-3.1-flash-lite",
                 displayName: "Gemini 3.1 Flash Lite"

--- a/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
+++ b/src/Tests/CLIProxyMenuBarTests/DroidProxyModelCatalogTests.swift
@@ -117,6 +117,20 @@ final class DroidProxyModelCatalogTests: XCTestCase {
         XCTAssertEqual(gemini["supportedReasoningEfforts"] as? [String], ["high"])
     }
 
+    func testGemini38FlashHighUsesAntigravityModelMetadata() throws {
+        let gemini = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:gemini-3.8-flash-high"))
+
+        XCTAssertEqual(gemini["model"] as? String, "gemini-3.8-flash-high")
+        XCTAssertEqual(gemini["provider"] as? String, "openai")
+        XCTAssertEqual(gemini["baseUrl"] as? String, "http://localhost:8317/v1")
+        XCTAssertEqual(gemini["displayName"] as? String, "DroidProxy: Antigravity: Gemini 3.8 Flash (High)")
+        XCTAssertEqual(gemini["maxOutputTokens"] as? Int, 65536)
+        XCTAssertEqual(gemini["enableThinking"] as? Bool, true)
+        XCTAssertEqual(gemini["reasoningEffort"] as? String, "high")
+        XCTAssertEqual(gemini["defaultReasoningEffort"] as? String, "high")
+        XCTAssertEqual(gemini["supportedReasoningEfforts"] as? [String], ["high"])
+    }
+
     func testGrok46UsesOpenAIProviderAndApiXAIProxy() throws {
         let grok = try XCTUnwrap(settingsEntry(id: "custom:droidproxy:grok-4.6"))
 


### PR DESCRIPTION
Adds the Antigravity Gemini 3.8 Flash (`gemini-3.8-flash-high`) model definition to `DroidProxyModelCatalog` and includes test coverage in `DroidProxyModelCatalogTests`.